### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,13 +8,11 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image,class: "item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <% if @item.order.present? %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
       <% end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -25,18 +23,14 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @item.user_id && @item.order.nil? %>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% elsif user_signed_in? && @item.order.nil? %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', item_orders_path(@item.id),class:"item-red-btn" %>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to '購入画面に進む', item_orders_path(@item.id),class:"item-red-btn" %>
     <% else %>
     <% end %>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,17 +23,16 @@
       </span>
     </div>
 
-    <% if user_signed_in? && current_user.id == @item.user_id && @item.order.nil? %>
-      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-      <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% elsif user_signed_in? && @item.order.nil? %>
-      <%= link_to '購入画面に進む', item_orders_path(@item.id),class:"item-red-btn" %>
-    <% else %>
-    <% end %>
-
+      <% if user_signed_in? && current_user.id == @item.user_id && @item.order.nil? %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% elsif user_signed_in? && @item.order.nil? %>
+        <%= link_to '購入画面に進む', item_orders_path(@item.id),class:"item-red-btn" %>
+      <% else %>
+      <% end %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.descriptions %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -98,7 +97,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,9 +9,11 @@
     <div class='item-img-content'>
       <%= image_tag @item.image,class: "item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <%# <div class='sold-out'> %>
-        <%# <span>Sold Out!!</span> %>
-      <%# </div> %>
+      <% if @item.order.present? %>
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
@@ -24,15 +26,15 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if user_signed_in? && current_user.id == @item.user_id %>
+    <% if user_signed_in? && current_user.id == @item.user_id && @item.order.nil? %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <% else %>
+    <% elsif user_signed_in? && @item.order.nil? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', item_orders_path(@item.id),class:"item-red-btn" %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% else %>
     <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 

--- a/spec/models/item_order_spec.rb
+++ b/spec/models/item_order_spec.rb
@@ -6,67 +6,66 @@ RSpec.describe ItemOrder, type: :model do
   end
 
   describe '購入履歴の保存' do
-    context "購入情報が保存できる場合" do
+    context '購入情報が保存できる場合' do
       it 'postal_codeとprefecture_idとcityとaddressesとbuildingとphone_numberとtokenとnumberとexp_monthととexp_yearとcvcとtokenがあれば保存ができること' do
         expect(@item_order).to be_valid
       end
-  
+
       it 'buildingは空でも登録できる' do
         @item_order.building = nil
         expect(@item_order).to be_valid
       end
     end
-  
-    context "購入情報が保存できない場合" do
+
+    context '購入情報が保存できない場合' do
       it 'postal_codeが空では登録できないこと' do
         @item_order.postal_code = nil
         @item_order.valid?
         expect(@item_order.errors.full_messages).to include("Postal code can't be blank")
       end
-    
+
       it 'postal_codeには-がないと登録できない' do
         @item_order.postal_code = '1234567'
         @item_order.valid?
         expect(@item_order.errors.full_messages).to include('Postal code is invalid. Include hyphen(-)')
       end
-    
+
       it 'prefecture_idが選択されていないと登録できない' do
         @item_order.prefecture_id = 1
         @item_order.valid?
         expect(@item_order.errors.full_messages).to include('Prefecture Select')
       end
-    
+
       it 'cityが空では登録できない' do
         @item_order.city = nil
         @item_order.valid?
         expect(@item_order.errors.full_messages).to include("City can't be blank")
       end
-    
+
       it 'addressesが空では登録できない' do
         @item_order.addresses = nil
         @item_order.valid?
         expect(@item_order.errors.full_messages).to include("Addresses can't be blank")
       end
-    
-      
+
       it 'phone_numberが空では登録できない' do
         @item_order.phone_number = nil
         @item_order.valid?
         expect(@item_order.errors.full_messages).to include("Phone number can't be blank")
       end
-    
+
       it 'phone_numberに-があると登録できない' do
         @item_order.phone_number = '03-123-4567'
         @item_order.valid?
         expect(@item_order.errors.full_messages).to include('Phone number Input only number')
       end
-    
+
       it 'phone_numberは11桁以内でないと登録できない' do
         @item_order.phone_number = '012345678901'
         @item_order.valid?
         expect(@item_order.errors.full_messages).to include('Phone number Input only number')
       end
-    
+
       it 'tokenが空では登録できない' do
         @item_order.token = nil
         @item_order.valid?


### PR DESCRIPTION
# What
商品詳細表示機能
・ログインしているユーザーの出品商品だと、「編集」「削除」が出る
　https://gyazo.com/5b0b66100cba98a8e3e9ed8c874cea95
・ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されない
　https://gyazo.com/47dde1c6c535b189c6ef55dbbe88f5a1
・ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示される
　https://gyazo.com/124cd05fc3282cb71c5228135cd4a5a9
・ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できる　
・ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されない
　https://gyazo.com/550576a1de57591e9f999fba02e23a54

# Why
商品詳細を見せる＋ログイン状態の有無、出品者か否か、購入されたかどうかで分岐させたい
